### PR TITLE
Implement basic chat interface in popup

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,4 @@
+/* global chrome */
 chrome.action.onClicked.addListener(() => {
   chrome.system.display.getInfo((displays) => {
     const display = displays[0];

--- a/src/popup/App.jsx
+++ b/src/popup/App.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import Chat from './Chat.jsx';
 
 function App() {
   return (
-    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
-      <h1>Bienvenido a Skanea</h1>
-      <p>Tu extensión está funcionando correctamente.</p>
+    <div style={{ height: '100vh', width: '100%', fontFamily: 'sans-serif' }}>
+      <Chat />
     </div>
   );
 }

--- a/src/popup/Chat.jsx
+++ b/src/popup/Chat.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+
+const API_URL = 'http://localhost:3000/api/chat';
+
+function Chat() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userText = input.trim();
+    setMessages((msgs) => [...msgs, { role: 'user', text: userText }]);
+    setInput('');
+    setLoading(true);
+    try {
+      const response = await fetch(API_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ message: userText }),
+      });
+      const data = await response.json();
+      setMessages((msgs) => [...msgs, { role: 'bot', text: data.response }]);
+    } catch (err) {
+      console.error(err);
+      setMessages((msgs) => [...msgs, { role: 'bot', text: 'Error al obtener respuesta' }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="messages">
+        {messages.map((m, index) => (
+          <div key={index} className={`message ${m.role}`}>{m.text}</div>
+        ))}
+        {loading && <div className="message bot">...</div>}
+      </div>
+      <form className="input-container" onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Escribe tu pregunta"
+        />
+        <button type="submit" disabled={loading}>
+          Enviar
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default Chat;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -14,3 +14,47 @@ h1 {
 p {
   font-size: 1rem;
 }
+
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.message {
+  margin-bottom: 0.5rem;
+}
+
+.message.user {
+  text-align: right;
+}
+
+.message.bot {
+  text-align: left;
+}
+
+.input-container {
+  display: flex;
+  border-top: 1px solid #333;
+}
+
+.input-container input {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+  background: #1a1b21;
+  color: white;
+}
+
+.input-container button {
+  padding: 0.5rem 1rem;
+  background: #006CFF;
+  color: white;
+  border: none;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,5 @@
+/* global __dirname */
+/* eslint-env node */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { viteStaticCopy } from 'vite-plugin-static-copy';


### PR DESCRIPTION
## Summary
- add new Chat component to handle messages and fetch backend responses
- wire Chat into App and adjust layout
- improve popup styles for chat layout
- add lint comments for chrome and __dirname globals

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68587c4772dc833084ff70c041578376