### PR TITLE
Add logo slot and toggleable chat history

### DIFF
--- a/src/popup/App.jsx
+++ b/src/popup/App.jsx
@@ -1,10 +1,39 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Chat from './Chat.jsx';
+import ChatHistory from './ChatHistory.jsx';
+import SettingsOverlay from './SettingsOverlay.jsx';
+import logo from '../../resources/icon.png';
 
 function App() {
+  const [showSettings, setShowSettings] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+
   return (
-    <div style={{ height: '100vh', width: '100%', fontFamily: 'sans-serif' }}>
-      <Chat />
+    <div className="app-container">
+      <div className="chat-area">
+        <div className="top-bar">
+          <button
+            className="history-btn"
+            onClick={() => setShowHistory(!showHistory)}
+            aria-label="Historial"
+          >
+            🕘
+          </button>
+          <div className="logo-container">
+            <img src={logo} alt="Skanea logo" className="logo" />
+          </div>
+          <button
+            className="settings-btn"
+            onClick={() => setShowSettings(true)}
+            aria-label="Ajustes"
+          >
+            ⚙️
+          </button>
+        </div>
+        <Chat />
+      </div>
+      {showHistory && <ChatHistory />}
+      {showSettings && <SettingsOverlay onClose={() => setShowSettings(false)} />}
     </div>
   );
 }

--- a/src/popup/App.jsx
+++ b/src/popup/App.jsx
@@ -16,6 +16,7 @@ function App() {
             className="history-btn"
             onClick={() => setShowHistory(!showHistory)}
             aria-label="Historial"
+            title="Historial"
           >
             🕘
           </button>
@@ -26,6 +27,7 @@ function App() {
             className="settings-btn"
             onClick={() => setShowSettings(true)}
             aria-label="Ajustes"
+            title="Ajustes"
           >
             ⚙️
           </button>

--- a/src/popup/ChatHistory.jsx
+++ b/src/popup/ChatHistory.jsx
@@ -1,16 +1,20 @@
 import React from 'react';
 
 function ChatHistory() {
-  const chats = ['Chat 1', 'Chat 2'];
+  const chats = [];
 
   return (
     <div className="chat-history">
       <h3>Historial</h3>
-      {chats.map((chat, index) => (
-        <div key={index} className="chat-history-item">
-          {chat}
-        </div>
-      ))}
+      {chats.length === 0 ? (
+        <div className="chat-history-empty">No hay conversaciones</div>
+      ) : (
+        chats.map((chat, index) => (
+          <div key={index} className="chat-history-item">
+            {chat}
+          </div>
+        ))
+      )}
     </div>
   );
 }

--- a/src/popup/ChatHistory.jsx
+++ b/src/popup/ChatHistory.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function ChatHistory() {
+  const chats = ['Chat 1', 'Chat 2'];
+
+  return (
+    <div className="chat-history">
+      {chats.map((chat, index) => (
+        <div key={index} className="chat-history-item">
+          {chat}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default ChatHistory;

--- a/src/popup/ChatHistory.jsx
+++ b/src/popup/ChatHistory.jsx
@@ -5,6 +5,7 @@ function ChatHistory() {
 
   return (
     <div className="chat-history">
+      <h3>Historial</h3>
       {chats.map((chat, index) => (
         <div key={index} className="chat-history-item">
           {chat}

--- a/src/popup/SettingsOverlay.jsx
+++ b/src/popup/SettingsOverlay.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function SettingsOverlay({ onClose }) {
+  return (
+    <div className="settings-overlay">
+      <div className="settings-window">
+        <button className="close-btn" onClick={onClose} aria-label="Cerrar">
+          ✕
+        </button>
+        <h2>Ajustes</h2>
+        <p>Configuraciones aquí...</p>
+      </div>
+    </div>
+  );
+}
+
+export default SettingsOverlay;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -18,7 +18,7 @@ p {
 .chat-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100%;
 }
 
 .messages {
@@ -57,4 +57,93 @@ p {
   background: #006CFF;
   color: white;
   border: none;
+}
+
+.app-container {
+  display: flex;
+  height: 100vh;
+  position: relative;
+}
+
+.chat-history {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 200px;
+  background: #1a1b21;
+  border-right: 1px solid #333;
+  overflow-y: auto;
+  padding: 0.5rem;
+  z-index: 5;
+}
+
+.chat-history-item {
+  padding: 0.5rem 0;
+  cursor: pointer;
+}
+
+.chat-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.settings-btn,
+.history-btn {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.logo-container {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.logo {
+  height: 24px;
+}
+
+.settings-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.settings-window {
+  background: #1a1b21;
+  border: 1px solid #333;
+  padding: 1rem;
+  position: relative;
+  width: 90%;
+  max-width: 400px;
+}
+
+.close-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 1.2rem;
+  cursor: pointer;
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -87,6 +87,12 @@ p {
   cursor: pointer;
 }
 
+.chat-history-empty {
+  padding: 0.5rem 0;
+  color: #aaa;
+  font-style: italic;
+}
+
 .chat-area {
   flex: 1;
   display: flex;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -78,6 +78,10 @@ p {
   z-index: 5;
 }
 
+.chat-history h3 {
+  margin: 0 0 0.5rem;
+}
+
 .chat-history-item {
   padding: 0.5rem 0;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- add Skanea logo asset import and UI slot
- center logo in top bar
- toggle chat history with a new button
- style top bar and history overlay

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68587faf25908330bb3e76e981a83715